### PR TITLE
Add option to resubmit a sample for analysis

### DIFF
--- a/backend/src/sample_flow_server/app.py
+++ b/backend/src/sample_flow_server/app.py
@@ -29,6 +29,7 @@ from sample_flow_server.model import (
     update_samples_zipfile,
     process_result,
     send_password_reset_email,
+    resubmit_sample,
 )
 
 
@@ -262,6 +263,15 @@ def create_app(data_path: str = "/sample_flow_data"):
         if not current_user.is_admin:
             return jsonify(message="Admin account required"), 401
         return jsonify(get_samples())
+
+    @app.route("/api/admin/resubmit_sample", methods=["POST"])
+    @jwt_required()
+    def admin_resubmit_sample():
+        if not current_user.is_admin:
+            return jsonify(message="Admin account required"), 401
+        primary_key = request.json.get("primary_key", "")
+        message, code = resubmit_sample(primary_key)
+        return jsonify(message=message), code
 
     @app.route("/api/admin/zipsamples", methods=["POST"])
     @jwt_required()

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -38,6 +38,7 @@ def add_test_samples(app):
                 email="user@embl.de",
                 name=name,
                 primary_key=key,
+                tube_primary_key=key,
                 reference_sequence_description=None,
                 running_option="running_option",
                 concentration=100 + 13 * n,

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -1,36 +1,55 @@
 <script setup lang="ts">
+// @ts-ignore
 import {
+  apiClient,
   download_reference_sequence,
   download_result,
 } from "@/utils/api-client";
 import type { Sample } from "@/utils/types";
 import BarCode from "@/components/BarCode.vue";
 
+function resubmit_sample(primary_key: string) {
+  apiClient
+    .post("admin/resubmit_sample", { primary_key: primary_key })
+    .then((response) => {
+      alert(response.data.message);
+      emit("sample_resubmitted");
+    })
+    .catch((error) => {
+      alert(error.response.data.message);
+    });
+}
+
 defineProps<{
   samples: Sample[];
-  show_email: boolean;
+  admin: boolean;
+  resubmit_button: boolean;
 }>();
+const emit = defineEmits(["sample_resubmitted"]);
 </script>
 
 <template>
   <table class="zebra" aria-label="Samples">
     <tr>
       <th>Primary Key</th>
-      <th v-if="show_email">Email</th>
+      <th v-if="admin">Tube Primary Key</th>
+      <th v-if="admin">Email</th>
       <th>Sample Name</th>
       <th>Running Option</th>
       <th>Concentration</th>
       <th>Reference Sequence</th>
       <th>Results</th>
+      <th v-if="admin && resubmit_button">Resubmit</th>
     </tr>
     <tr v-for="sample in samples" :key="sample.id">
       <td>
-        <template v-if="show_email">{{ sample["primary_key"] }}</template>
+        <template v-if="admin">{{ sample["primary_key"] }}</template>
         <template v-else>
           <BarCode :value="sample['primary_key']"></BarCode>
         </template>
       </td>
-      <td v-if="show_email">{{ sample["email"] }}</td>
+      <td v-if="admin">{{ sample["tube_primary_key"] }}</td>
+      <td v-if="admin">{{ sample["email"] }}</td>
       <td>{{ sample["name"] }}</td>
       <td>{{ sample["running_option"] }}</td>
       <td>{{ sample["concentration"] }} ng/μl</td>
@@ -82,6 +101,11 @@ defineProps<{
             >
           </template>
         </template>
+      </td>
+      <td v-if="admin && resubmit_button">
+        <button @click="resubmit_sample(sample.tube_primary_key)">
+          Resubmit
+        </button>
       </td>
     </tr>
   </table>

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,6 +1,7 @@
 export type Sample = {
   id: number;
   primary_key: string;
+  tube_primary_key: string;
   name: string;
   email: string;
   running_option: string;

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -21,10 +21,14 @@ function generate_api_token() {
 const current_samples = ref([] as Sample[]);
 const previous_samples = ref([] as Sample[]);
 
-apiClient.get("admin/samples").then((response) => {
-  current_samples.value = response.data.current_samples;
-  previous_samples.value = response.data.previous_samples;
-});
+function get_samples() {
+  apiClient.get("admin/samples").then((response) => {
+    current_samples.value = response.data.current_samples;
+    previous_samples.value = response.data.previous_samples;
+  });
+}
+
+get_samples();
 
 const users = ref([] as User[]);
 apiClient.get("admin/users").then((response) => {
@@ -125,7 +129,8 @@ function upload_result() {
       <p>{{ current_samples.length }} samples have been requested so far:</p>
       <SamplesTable
         :samples="current_samples"
-        :show_email="true"
+        :admin="true"
+        :resubmit_button="false"
       ></SamplesTable>
       <p>
         <a href="" @click.prevent="download_zipsamples()">
@@ -255,7 +260,9 @@ function upload_result() {
     <ListItem title="Previous samples" icon="bi-gear">
       <SamplesTable
         :samples="previous_samples"
-        :show_email="true"
+        :admin="true"
+        :resubmit_button="true"
+        @sample_resubmitted="get_samples"
       ></SamplesTable>
     </ListItem>
     <ListItem title="Users" icon="bi-gear">

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -135,7 +135,8 @@ function add_sample() {
         <p>Your samples for this week:</p>
         <SamplesTable
           :samples="current_samples"
-          :show_email="false"
+          :admin="false"
+          :resubmit_button="false"
         ></SamplesTable>
       </template>
       <template v-else>
@@ -238,7 +239,8 @@ function add_sample() {
         <p>Results from your previous samples:</p>
         <SamplesTable
           :samples="previous_samples"
-          :show_email="false"
+          :admin="false"
+          :resubmit_button="false"
         ></SamplesTable>
       </template>
       <template v-else>


### PR DESCRIPTION
- add `/admin/resubmit_sample` endpoint to API
- add `resubmit` button to admin samples table in web interface
- add `tube_primary_key` column to samples database
  - for new samples this matches the `primary_key`
- when a sample is re-submitted
  - a new sample with new primary key is created
  - a new sample is created which is a copy of the original sample except for
    - `date` is the resubmission date
    - `email` is "RESUBMITTED" - `primary_key` is a new primary key
- re-submitted samples are not visible to users, only to admins
- results uploaded for a re-submitted sample are assigned to the original sample
- resolves #81