### PR TITLE
Redirect to login page when jwt token expires

### DIFF
--- a/backend/src/sample_flow_server/app.py
+++ b/backend/src/sample_flow_server/app.py
@@ -46,8 +46,8 @@ def create_app(data_path: str = "/sample_flow_data"):
         )
         # new secret key -> invalidates any existing tokens
         app.config["JWT_SECRET_KEY"] = secrets.token_urlsafe(64)
-    # tokens are by default valid for 30mins
-    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = datetime.timedelta(minutes=30)
+    # tokens are by default valid for 1 hour
+    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = datetime.timedelta(minutes=60)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{data_path}/SampleFlow.db"
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     # limit max file upload size to 384mb
@@ -82,13 +82,13 @@ def create_app(data_path: str = "/sample_flow_data"):
         ).scalar_one_or_none()
         if not user:
             logger.info("  -> user not found")
-            return jsonify(message="Unknown email address"), 401
+            return jsonify(message="Unknown email address"), 400
         if not user.activated:
             logger.info("  -> user not activated")
-            return jsonify(message="User account is not yet activated"), 401
+            return jsonify(message="User account is not yet activated"), 400
         if not user.check_password(password):
             logger.info("  -> wrong password")
-            return jsonify(message="Incorrect password"), 401
+            return jsonify(message="Incorrect password"), 400
         logger.info("  -> returning JWT access token")
         access_token = create_access_token(identity=user)
         return jsonify(user=user.as_dict(), access_token=access_token)
@@ -115,13 +115,13 @@ def create_app(data_path: str = "/sample_flow_data"):
     def reset_password():
         token = request.json.get("reset_token", None)
         if token is None:
-            return jsonify(message="Reset token missing"), 401
+            return jsonify(message="Reset token missing"), 400
         email = request.json.get("email", None)
         if email is None:
-            return jsonify(message="Email address missing"), 401
+            return jsonify(message="Email address missing"), 400
         new_password = request.json.get("new_password", None)
         if new_password is None:
-            return jsonify(message="New password missing"), 401
+            return jsonify(message="New password missing"), 400
         message, code = reset_user_password(token, email, new_password)
         return jsonify(message=message), code
 
@@ -130,16 +130,16 @@ def create_app(data_path: str = "/sample_flow_data"):
     def change_password():
         current_password = request.json.get("current_password", None)
         if current_password is None:
-            return jsonify(message="Current password missing"), 401
+            return jsonify(message="Current password missing"), 400
         new_password = request.json.get("new_password", None)
         if new_password is None:
-            return jsonify(message="New password missing"), 401
+            return jsonify(message="New password missing"), 400
         logger.info(f"Password change request from {current_user.email}")
         if current_user.set_password(current_password, new_password):
             return jsonify(message="Password changed.")
         return (
             jsonify(message="Failed to change password: current password incorrect."),
-            401,
+            400,
         )
 
     @app.route("/api/remaining", methods=["GET"])
@@ -172,16 +172,16 @@ def create_app(data_path: str = "/sample_flow_data"):
         ).scalar_one_or_none()
         if user_sample is None:
             logger.info(f"  -> sample with key {primary_key} not found")
-            return jsonify(message="Sample not found"), 401
+            return jsonify(message="Sample not found"), 400
         if not user_sample.has_reference_seq_zip:
             logger.info(
                 f"  -> sample with key {primary_key} found but does not contain a reference sequence"
             )
-            return jsonify(message="Sample does not contain a reference sequence"), 401
+            return jsonify(message="Sample does not contain a reference sequence"), 400
         requested_file = pathlib.Path(user_sample.reference_seq_zip_path())
         if not requested_file.is_file():
             logger.info(f"  -> file {requested_file} not found")
-            return jsonify(message=f"Reference sequence file not found"), 401
+            return jsonify(message=f"Reference sequence file not found"), 400
         logger.info(f"Returning file {user_sample.reference_seq_zip_path()}")
         return flask.send_file(user_sample.reference_seq_zip_path(), as_attachment=True)
 
@@ -200,16 +200,16 @@ def create_app(data_path: str = "/sample_flow_data"):
         ).scalar_one_or_none()
         if user_sample is None:
             logger.info(f"  -> sample with key {primary_key} not found")
-            return jsonify(message="Sample not found"), 401
+            return jsonify(message="Sample not found"), 400
         if not user_sample.has_results_zip:
             logger.info(
                 f"  -> sample with key {primary_key} found but no results available"
             )
-            return jsonify(message=f"No results available"), 401
+            return jsonify(message=f"No results available"), 400
         requested_file = pathlib.Path(user_sample.results_file_path())
         if not requested_file.is_file():
             logger.info(f"  -> file {requested_file} not found")
-            return jsonify(message=f"Results file not found"), 401
+            return jsonify(message=f"Results file not found"), 400
         logger.info(f"Returning file {requested_file}")
         return flask.send_file(requested_file, as_attachment=True)
 
@@ -229,13 +229,13 @@ def create_app(data_path: str = "/sample_flow_data"):
         if new_sample is not None:
             logger.info(f"  - > success")
             return jsonify(sample=new_sample)
-        return jsonify(message=error_message), 401
+        return jsonify(message=error_message), 400
 
     @app.route("/api/admin/settings", methods=["GET", "POST"])
     @jwt_required()
     def admin_settings():
         if not current_user.is_admin:
-            return jsonify(message="Admin account required"), 401
+            return jsonify(message="Admin account required"), 400
         if flask.request.method == "POST":
             message, code = set_current_settings(current_user.email, request.json)
             return jsonify(message=message), code
@@ -246,14 +246,14 @@ def create_app(data_path: str = "/sample_flow_data"):
     @jwt_required()
     def admin_all_samples():
         if not current_user.is_admin:
-            return jsonify(message="Admin account required"), 401
+            return jsonify(message="Admin account required"), 400
         return jsonify(get_samples())
 
     @app.route("/api/admin/resubmit_sample", methods=["POST"])
     @jwt_required()
     def admin_resubmit_sample():
         if not current_user.is_admin:
-            return jsonify(message="Admin account required"), 401
+            return jsonify(message="Admin account required"), 400
         primary_key = request.json.get("primary_key", "")
         message, code = resubmit_sample(primary_key)
         return jsonify(message=message), code
@@ -262,7 +262,7 @@ def create_app(data_path: str = "/sample_flow_data"):
     @jwt_required()
     def admin_zip_samples():
         if not current_user.is_admin:
-            return jsonify(message="Admin account required"), 401
+            return jsonify(message="Admin account required"), 400
         logger.info(
             f"Request for zipfile of samples from Admin user {current_user.email}"
         )
@@ -275,7 +275,7 @@ def create_app(data_path: str = "/sample_flow_data"):
         if current_user.is_admin:
             users = db.session.execute(db.select(User)).scalars().all()
             return jsonify(users=[user.as_dict() for user in users])
-        return jsonify(message="Admin account required"), 401
+        return jsonify(message="Admin account required"), 400
 
     @app.route("/api/admin/token", methods=["GET"])
     @jwt_required()
@@ -285,13 +285,13 @@ def create_app(data_path: str = "/sample_flow_data"):
                 identity=current_user, expires_delta=datetime.timedelta(weeks=26)
             )
             return jsonify(access_token=access_token)
-        return jsonify(message="Admin account required"), 401
+        return jsonify(message="Admin account required"), 400
 
     @app.route("/api/admin/result", methods=["POST"])
     @jwt_required()
     def admin_upload_result():
         if not current_user.is_admin:
-            return jsonify(message="Admin account required"), 401
+            return jsonify(message="Admin account required"), 400
         email = current_user.email
         form_as_dict = request.form.to_dict()
         primary_key = form_as_dict.get("primary_key", "")
@@ -299,12 +299,12 @@ def create_app(data_path: str = "/sample_flow_data"):
         logger.info(f"Result upload for '{primary_key}' from user {email}")
         if success is None or success.lower() not in ["true", "false"]:
             logger.info(f"  -> missing success key")
-            return jsonify(message="Missing key: success=True/False"), 401
+            return jsonify(message="Missing key: success=True/False"), 400
         success = success.lower() == "true"
         zipfile = request.files.to_dict().get("file", None)
         if success is True and zipfile is None:
             logger.info(f"  -> missing zipfile")
-            return jsonify(message="Result has success=True but no file"), 401
+            return jsonify(message="Result has success=True but no file"), 400
         message, code = process_result(primary_key, success, zipfile)
         return jsonify(message=message), code
 

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -2,6 +2,8 @@ import argon2
 from sample_flow_server.model import User, Sample, db
 import datetime
 import pathlib
+import shutil
+import tempfile
 
 
 def add_test_users(app):
@@ -37,8 +39,10 @@ def add_test_samples(app, data_path: pathlib.Path):
             key = f"22_{week}_A{n}"
             ref_dir = data_path / "2022" / f"{week}" / "inputs" / "references"
             ref_dir.mkdir(parents=True, exist_ok=True)
-            with open(ref_dir / f"{key}_{name}.zip", "w") as f:
-                f.write("abc123")
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                with open(f"{tmp_dir}/test.txt", "w") as f:
+                    f.write(key)
+                shutil.make_archive(f"{ref_dir}/{key}_{name}", "zip", tmp_dir)
             new_sample = Sample(
                 email="user@embl.de",
                 name=name,

--- a/backend/tests/test_model.py
+++ b/backend/tests/test_model.py
@@ -33,7 +33,7 @@ def test_settings(app, tmp_path):
         assert new_settings["plate_n_cols"] == 18
         # settings dict missing required fields is a no-op
         msg, code = model.set_current_settings(email, {"plate_n_rows": 10})
-        assert code == 401
+        assert code == 400
         assert "settings not updated" in msg
         assert _count_settings() == 2
         assert new_settings["plate_n_rows"] == 14
@@ -165,7 +165,7 @@ def test_add_new_user_invalid(app):
     with app.app_context():
         for email in ["joe@gmail.com", "@embl.de"]:
             msg, code = model.add_new_user(email, password_valid, is_admin=False)
-            assert code == 401
+            assert code == 400
             assert "email" in msg
         for password in [
             "",
@@ -175,10 +175,10 @@ def test_add_new_user_invalid(app):
             "asd!(*&@#@!(*#%ASDASDFGK",
         ]:
             msg, code = model.add_new_user(email_valid, password, is_admin=False)
-            assert code == 401
+            assert code == 400
             assert "Password" in msg
         msg, code = model.add_new_user("user@embl.de", password_valid, is_admin=False)
-        assert code == 401
+        assert code == 400
         assert msg == "This email address is already in use"
 
 
@@ -269,12 +269,12 @@ def test_process_result_invalid(app):
     with app.app_context():
         # no primary key
         message, code = model.process_result("", False, None)
-        assert code == 401
+        assert code == 400
         assert "key" in message
         # valid key, success = True but no file
         primary_key = "22_46_A1"
         message, code = model.process_result(primary_key, True, None)
-        assert code == 401
+        assert code == 400
         assert "file" in message
 
 
@@ -307,13 +307,13 @@ def test_reset_password(app):
         # use incorrect token
         msg, code = model.reset_user_password("wrongtoken", email, new_password)
         assert "invalid" in msg.lower()
-        assert code == 401
+        assert code == 400
         # use incorrect email
         msg, code = model.reset_user_password(
             reset_token, "wrong@email.com", new_password
         )
         assert "invalid" in msg.lower()
-        assert code == 401
+        assert code == 400
         # use correct token & email
         msg, code = model.reset_user_password(reset_token, email, new_password)
         assert "password changed" in msg.lower()

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { apiClient } from "@/utils/api-client";
+import { apiClient, logout } from "@/utils/api-client";
 import { validate_password } from "@/utils/validation";
 import { useUserStore } from "@/stores/user";
 import ListItem from "@/components/ListItem.vue";
@@ -41,6 +41,9 @@ function do_change_password() {
       response_message.value = response.data.message;
     })
     .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
       response_message.value = error.response.data.message;
     });
 }

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -2,6 +2,7 @@
 // @ts-ignore
 import {
   apiClient,
+  logout,
   download_reference_sequence,
   download_result,
 } from "@/utils/api-client";
@@ -16,6 +17,9 @@ function resubmit_sample(primary_key: string) {
       emit("sample_resubmitted");
     })
     .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
       alert(error.response.data.message);
     });
 }

--- a/frontend/src/utils/api-client.ts
+++ b/frontend/src/utils/api-client.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import router from "@/router";
 import type { AxiosInstance } from "axios";
 import { useUserStore } from "@/stores/user";
 
@@ -34,6 +35,11 @@ function download_file_from_endpoint(
       link.setAttribute("download", filename);
       document.body.appendChild(link);
       link.click();
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
     });
 }
 
@@ -57,8 +63,16 @@ function download_zipsamples() {
   download_file_from_endpoint("admin/zipsamples", {}, "samples.zip");
 }
 
+function logout() {
+  const user = useUserStore();
+  user.user = null;
+  user.token = "";
+  router.push({ name: "login" });
+}
+
 export {
   apiClient,
+  logout,
   download_zipsamples,
   download_reference_sequence,
   download_result,

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -3,7 +3,7 @@ import ListItem from "@/components/ListItem.vue";
 import SamplesTable from "@/components/SamplesTable.vue";
 import { ref, computed } from "vue";
 import type { Sample, User, Settings } from "@/utils/types";
-import { apiClient, download_zipsamples } from "@/utils/api-client";
+import { apiClient, download_zipsamples, logout } from "@/utils/api-client";
 
 function generate_api_token() {
   apiClient.get("admin/token").then((response) => {
@@ -12,7 +12,10 @@ function generate_api_token() {
       .then(() => {
         console.log("API token copied to clipboard");
       })
-      .catch(() => {
+      .catch((error) => {
+        if (error.response.status > 400) {
+          logout();
+        }
         console.log("Failed to copy API token to clipboard");
       });
   });
@@ -22,28 +25,52 @@ const current_samples = ref([] as Sample[]);
 const previous_samples = ref([] as Sample[]);
 
 function get_samples() {
-  apiClient.get("admin/samples").then((response) => {
-    current_samples.value = response.data.current_samples;
-    previous_samples.value = response.data.previous_samples;
-  });
+  apiClient
+    .get("admin/samples")
+    .then((response) => {
+      current_samples.value = response.data.current_samples;
+      previous_samples.value = response.data.previous_samples;
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
 }
 
 get_samples();
 
 const users = ref([] as User[]);
-apiClient.get("admin/users").then((response) => {
-  users.value = response.data.users;
-});
+apiClient
+  .get("admin/users")
+  .then((response) => {
+    users.value = response.data.users;
+  })
+  .catch((error) => {
+    if (error.response.status > 400) {
+      logout();
+    }
+    console.log(error);
+  });
 
 const settings = ref({} as Settings);
 const days = [1, 2, 3, 4, 5, 6, 7];
 const last_submission_day = ref(1);
 const new_running_option = ref("");
 const settings_message = ref("");
-apiClient.get("admin/settings").then((response) => {
-  settings.value = response.data;
-  last_submission_day.value = settings.value.last_submission_day;
-});
+apiClient
+  .get("admin/settings")
+  .then((response) => {
+    settings.value = response.data;
+    last_submission_day.value = settings.value.last_submission_day;
+  })
+  .catch((error) => {
+    if (error.response.status > 400) {
+      logout();
+    }
+    console.log(error);
+  });
 
 function add_running_option() {
   settings.value.running_options.push(new_running_option.value);
@@ -80,6 +107,9 @@ function save_settings() {
       settings_message.value = response.data.message;
     })
     .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
       settings_message.value = error.response.data.message;
     });
 }
@@ -117,6 +147,9 @@ function upload_result() {
         upload_result_message.value = response.data.message;
       })
       .catch((error) => {
+        if (error.response.status > 400) {
+          logout();
+        }
         upload_result_message.value = error.response.data.message;
       });
   }

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ListItem from "@/components/ListItem.vue";
 import { ref, computed } from "vue";
-import { apiClient } from "@/utils/api-client";
+import { apiClient, logout } from "@/utils/api-client";
 import { validate_password } from "@/utils/validation";
 const props = defineProps({ reset_token: String });
 
@@ -46,6 +46,9 @@ function reset_password() {
       show_form.value = false;
     })
     .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
       if (error.response != null) {
         message.value = error.response.data.message;
       } else {

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 import ListItem from "@/components/ListItem.vue";
 import SamplesTable from "@/components/SamplesTable.vue";
-import { apiClient } from "@/utils/api-client";
+import { apiClient, logout } from "@/utils/api-client";
 import { validate_sample_name } from "@/utils/validation";
 import type { Sample, RunningOptions } from "@/utils/types";
 
@@ -89,6 +89,9 @@ apiClient
     previous_samples.value = response.data.previous_samples;
   })
   .catch((error) => {
+    if (error.response.status > 400) {
+      logout();
+    }
     console.log(error);
   });
 
@@ -104,6 +107,9 @@ apiClient
     }
   })
   .catch((error) => {
+    if (error.response.status > 400) {
+      logout();
+    }
     console.log(error);
   });
 
@@ -128,6 +134,9 @@ function add_sample() {
       new_sample_error_message.value = "";
     })
     .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
       new_sample_error_message.value = error.response.data.message;
     });
   update_remaining();


### PR DESCRIPTION
- replace all our existing `401` error codes with `400` in backend
- redirect to login page in frontend whenever we get an error code >400
  - 401 and 422 are the error codes used by jwt
- increase token timeout to 1 hour
- resolves #53
